### PR TITLE
Add multimodal linear regression oral exam backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+*.sqlite3
+storage/vector_store/
+celerybeat-schedule
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-# Interview
+# Multimodal Linear Regression Oral Exam Platform
+
+This repository contains a FastAPI-based backend that administers an oral assessment on linear regression. It orchestrates audio transcription, retrieval-augmented grading, and multimodal delivery analysis in near real time. The system is intentionally modular so it can run entirely on free/open models while still allowing upgrades to hosted APIs when desired.
+
+## Features
+
+- **Question retrieval** – Questions and curated reference answers are stored in a Chroma vector database. Each session randomly selects a prompt from this bank and persists it for later grading.
+- **Speech-to-text** – Audio submissions are transcribed with [OpenAI Whisper](https://github.com/openai/whisper) (any local size can be configured).
+- **Retrieval-Augmented Evaluation** – The transcript is matched against vetted context chunks and graded by either a local `llama.cpp` model or a deterministic heuristic. Output is a structured JSON summary of strengths, missed concepts, and accuracy scores.
+- **Computer vision & VLM analysis** – Key frames are sampled from the webcam video, gestures are detected with MediaPipe, and optional descriptions can be produced with an open VLM such as LLaVA.
+- **Composite reporting** – Content and delivery insights are fused into a final instructor-facing report with configurable weighting.
+- **Asynchronous processing** – Long-running workloads can be dispatched either via FastAPI background tasks or the included Celery worker template for horizontal scaling.
+
+## Project Layout
+
+```
+app/
+  api/            # REST endpoints
+  config.py       # Pydantic settings (env aware)
+  db/             # Vector store wrapper (Chroma)
+  models/         # Dataclasses for domain objects
+  services/       # Core orchestration: STT, RAG, CV/VLM, reporting, etc.
+  main.py         # FastAPI application factory
+celery_app.py     # Celery worker entry point (optional)
+data/questions.json
+requirements.txt
+```
+
+## Quick Start
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+   > ℹ️ Whisper and MediaPipe rely on `ffmpeg`. Install it through your OS package manager when running the full pipeline.
+
+2. **Prepare optional models**
+
+   - **LLM (content grading)**: download any `gguf` model compatible with [`llama.cpp`](https://github.com/ggerganov/llama.cpp). Update `INTERVIEW_LLM_MODEL_PATH` in `.env` to point to the file. If omitted, the system falls back to a deterministic heuristic.
+   - **Vision-Language Model**: to enable multimodal narration, set `INTERVIEW_ENABLE_VLM=true` and `INTERVIEW_VLM_MODEL_NAME` to a Hugging Face repo such as `liuhaotian/llava-v1.5-7b-hf`. Running these models typically requires a GPU.
+
+3. **Start the API**
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+4. **(Optional) Start Celery worker**
+
+   ```bash
+   celery -A celery_app.celery_app worker --loglevel=info
+   ```
+
+   Set `INTERVIEW_USE_CELERY=true` in your environment and the API will enqueue jobs on the Celery worker instead of processing them inline. The built-in FastAPI background tasks remain the default for lightweight experimentation.
+
+## API Walkthrough
+
+1. `POST /exam/start` – Creates a new session, selects a question, and returns `{session_id, question, max_response_duration}`.
+2. `POST /exam/{session_id}/submit` – Accepts multipart form data containing optional audio (`audio`), optional video (`video`), and/or a text transcript (`transcript`). The submission is queued for processing.
+3. `POST /exam/submit-transcript` – Lightweight JSON endpoint for manual transcripts without media uploads.
+4. `GET /exam/{session_id}` – Poll for session status and retrieve the final report once processing finishes.
+5. `GET /health` – Simple liveness probe.
+
+The final report is structured as:
+
+```json
+{
+  "question_asked": "...",
+  "student_answer_transcript": "...",
+  "content_analysis": {
+    "accuracy_score": 82.5,
+    "missed_concepts": ["Gauss-Markov optimality"],
+    "errors_made": ["Confused homoscedasticity with independence"],
+    "correct_points": ["Defined least squares objective"],
+    "confidence": 78.0
+  },
+  "delivery_analysis": {
+    "gestures_detected": ["pointing", "counting"],
+    "confidence_estimate": "high",
+    "engagement_level": "medium",
+    "notes": ["Student appeared confident and used demonstrative gestures..."]
+  },
+  "composite_score": 84.1
+}
+```
+
+## Configuration Reference
+
+All settings may be overridden via environment variables (prefix `INTERVIEW_`). Key options:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `INTERVIEW_DATASET_PATH` | `data/questions.json` | Location of curated question bank |
+| `INTERVIEW_VECTOR_STORE_PATH` | `storage/vector_store` | Persistence directory for Chroma |
+| `INTERVIEW_TRANSCRIPTION_MODEL` | `base` | Whisper model variant |
+| `INTERVIEW_LLM_MODEL_PATH` | `None` | Path to a local `gguf` model used for grading |
+| `INTERVIEW_ENABLE_VLM` | `False` | Enables the VLM layer (requires GPU-capable model) |
+| `INTERVIEW_VLM_MODEL_NAME` | `None` | Hugging Face repository for the VLM |
+| `INTERVIEW_COMPOSITE_SCORE_CONTENT_WEIGHT` | `0.7` | Weight assigned to content accuracy |
+| `INTERVIEW_COMPOSITE_SCORE_DELIVERY_WEIGHT` | `0.3` | Weight assigned to delivery |
+| `INTERVIEW_CELERY_BROKER_URL` | `redis://localhost:6379/0` | Celery broker |
+| `INTERVIEW_CELERY_RESULT_BACKEND` | `redis://localhost:6379/1` | Celery results backend |
+| `INTERVIEW_USE_CELERY` | `False` | Dispatch processing jobs to Celery instead of FastAPI background tasks |
+
+## Extending the System
+
+- **Additional questions**: append entries to `data/questions.json` (ensure unique `id`s). They are automatically embedded into the Chroma collection on startup.
+- **Alternate STT or VLM backends**: implement a new service satisfying the respective interfaces (`TranscriptionService` or `BaseVisionLanguageModel`) and wire it through `app/dependencies.py`.
+- **Analytics dashboards**: consume the JSON reports produced by `AssessmentPipeline` to visualise student progress or feed downstream grading workflows.
+
+## Testing Notes
+
+Due to the heavy multimedia dependencies, unit tests are not bundled with this prototype. When integrating into CI, prefer mocking the Whisper, LLM, and MediaPipe layers to avoid large downloads while still exercising the orchestration code paths.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile, status
+
+from app.config import Settings, get_settings
+from app.models.domain import CompositeReport
+from app.schemas import (
+    ContentEvaluationModel,
+    ExamReportModel,
+    ExamStatusResponse,
+    QuestionResponse,
+    SubmissionResponse,
+    TranscriptOnlyRequest,
+    VisualAnalysisModel,
+)
+from app.dependencies import get_pipeline, get_question_service, get_session_store
+from app.services.pipeline import AssessmentPipeline
+from app.services.question_service import QuestionService
+from app.services.session import SessionStore
+
+router = APIRouter()
+
+
+def _persist_upload(upload: UploadFile, suffix: str) -> Path:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        shutil.copyfileobj(upload.file, tmp)
+        tmp_path = Path(tmp.name)
+    upload.file.close()
+    return tmp_path
+
+
+def _serialize_report(report: CompositeReport) -> ExamReportModel:
+    return ExamReportModel(
+        question_asked=report.question_asked,
+        student_answer_transcript=report.student_answer_transcript,
+        content_analysis=ContentEvaluationModel(
+            accuracy_score=report.content_analysis.accuracy_score,
+            missed_concepts=report.content_analysis.missed_concepts,
+            errors_made=report.content_analysis.errors_made,
+            correct_points=report.content_analysis.correct_points,
+            confidence=report.content_analysis.confidence,
+        ),
+        delivery_analysis=VisualAnalysisModel(
+            gestures_detected=report.delivery_analysis.gestures_detected,
+            confidence_estimate=report.delivery_analysis.confidence_estimate,
+            engagement_level=report.delivery_analysis.engagement_level,
+            notes=report.delivery_analysis.notes,
+        ),
+        composite_score=report.composite_score,
+    )
+
+
+@router.get("/health")
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.post("/exam/start", response_model=QuestionResponse)
+def start_exam(question_service: QuestionService = Depends(get_question_service)) -> QuestionResponse:
+    session = question_service.start_new_session()
+    return QuestionResponse(
+        session_id=session.session_id,
+        question=session.question.question,
+        max_response_duration=question_service.answer_duration_seconds,
+    )
+
+
+@router.post("/exam/{session_id}/submit", response_model=SubmissionResponse, status_code=status.HTTP_202_ACCEPTED)
+async def submit_response(
+    session_id: str,
+    background_tasks: BackgroundTasks,
+    pipeline: AssessmentPipeline = Depends(get_pipeline),
+    session_store: SessionStore = Depends(get_session_store),
+    settings: Settings = Depends(get_settings),
+    audio: Optional[UploadFile] = File(default=None),
+    video: Optional[UploadFile] = File(default=None),
+    transcript: Optional[str] = Form(default=None),
+) -> SubmissionResponse:
+    if session_store.maybe_get(session_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown session_id")
+
+    audio_path: Optional[Path] = None
+    video_path: Optional[Path] = None
+    if audio is not None:
+        audio_path = _persist_upload(audio, suffix=".wav")
+    if video is not None:
+        video_path = _persist_upload(video, suffix=".mp4")
+
+    if settings.use_celery:
+        from celery_app import process_submission_task
+
+        process_submission_task.delay(
+            session_id,
+            str(audio_path) if audio_path else None,
+            str(video_path) if video_path else None,
+            transcript,
+        )
+    else:
+        background_tasks.add_task(pipeline.process, session_id, audio_path, video_path, transcript)
+    return SubmissionResponse(session_id=session_id, status="processing")
+
+
+@router.post("/exam/submit-transcript", response_model=SubmissionResponse, status_code=status.HTTP_202_ACCEPTED)
+async def submit_transcript(
+    payload: TranscriptOnlyRequest,
+    background_tasks: BackgroundTasks,
+    pipeline: AssessmentPipeline = Depends(get_pipeline),
+    session_store: SessionStore = Depends(get_session_store),
+) -> SubmissionResponse:
+    if session_store.maybe_get(payload.session_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown session_id")
+
+    background_tasks.add_task(pipeline.process, payload.session_id, None, None, payload.transcript)
+    return SubmissionResponse(session_id=payload.session_id, status="processing")
+
+
+@router.get("/exam/{session_id}", response_model=ExamStatusResponse)
+def get_status(
+    session_id: str,
+    session_store: SessionStore = Depends(get_session_store),
+) -> ExamStatusResponse:
+    try:
+        session = session_store.get(session_id)
+    except KeyError as exc:  # pragma: no cover - simple pass-through
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown session_id") from exc
+
+    report: Optional[CompositeReport] = session.report
+    serialized = _serialize_report(report) if report else None
+    return ExamStatusResponse(session_id=session_id, status=session.status, report=serialized)

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables when available."""
+
+    app_name: str = "Linear Regression Oral Exam Platform"
+    dataset_path: Path = Path(__file__).resolve().parent.parent / "data" / "questions.json"
+    vector_store_path: Path = Path(__file__).resolve().parent.parent / "storage" / "vector_store"
+    collection_name: str = "linear_regression_questions"
+    embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+
+    transcription_model: str = "base"
+    transcription_language: Optional[str] = "en"
+    sample_rate: int = 16_000
+    question_duration_seconds: int = 60
+
+    llm_model_path: Optional[str] = None
+    llm_temperature: float = 0.2
+    llm_max_tokens: int = 768
+
+    evaluation_prompt_template: str = (
+        "You are a strict statistics professor assessing an oral answer. "
+        "Compare the transcript with the verified context and question. "
+        "Return a JSON object with keys accuracy_score (0-100), missed_concepts (list), "
+        "errors_made (list), correct_points (list), and confidence (0-100)."
+    )
+
+    enable_vlm: bool = False
+    vlm_model_name: Optional[str] = None
+    vlm_device: str = "cpu"
+    keyframe_window_seconds: float = 3.0
+    max_keyframes: int = 10
+    gesture_confidence_threshold: float = 0.5
+
+    composite_score_content_weight: float = 0.7
+    composite_score_delivery_weight: float = 0.3
+
+    celery_broker_url: str = "redis://localhost:6379/0"
+    celery_result_backend: str = "redis://localhost:6379/1"
+    use_celery: bool = False
+
+    model_config = SettingsConfigDict(env_prefix="INTERVIEW_", env_file=".env", env_file_encoding="utf-8")
+
+    def ensure_directories(self) -> None:
+        """Make sure directories referenced in settings exist."""
+
+        self.vector_store_path.mkdir(parents=True, exist_ok=True)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    settings = Settings()
+    settings.ensure_directories()
+    return settings

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,3 @@
+from .vector_store import QuestionVectorStore
+
+__all__ = ["QuestionVectorStore"]

--- a/app/db/vector_store.py
+++ b/app/db/vector_store.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import chromadb
+from chromadb.utils import embedding_functions
+
+from app.models.domain import QuestionEntry
+
+
+class QuestionVectorStore:
+    """Lightweight wrapper around ChromaDB for managing the question bank."""
+
+    def __init__(
+        self,
+        dataset_path: Path,
+        persist_directory: Path,
+        collection_name: str,
+        embedding_model: str,
+    ) -> None:
+        self._dataset_path = dataset_path
+        self._persist_directory = persist_directory
+        self._collection_name = collection_name
+        self._embedding_model = embedding_model
+
+        self._client = chromadb.PersistentClient(path=str(persist_directory))
+        embedding_fn = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=embedding_model)
+        self._collection = self._client.get_or_create_collection(
+            name=collection_name, embedding_function=embedding_fn
+        )
+        self._questions: Dict[str, QuestionEntry] = {}
+        self._load_dataset()
+
+    def _load_dataset(self) -> None:
+        if not self._dataset_path.exists():
+            raise FileNotFoundError(f"Dataset not found at {self._dataset_path}")
+
+        with self._dataset_path.open("r", encoding="utf-8") as fh:
+            payload: Sequence[Dict[str, object]] = json.load(fh)
+
+        existing_ids = set(self._collection.get()["ids"] or [])
+
+        for raw_entry in payload:
+            entry = QuestionEntry(
+                id=str(raw_entry["id"]),
+                question=str(raw_entry["question"]),
+                answer=str(raw_entry["answer"]),
+                citations=list(raw_entry.get("citations", [])),
+                key_points=list(raw_entry.get("key_points", [])),
+            )
+            self._questions[entry.id] = entry
+
+            if entry.id in existing_ids:
+                continue
+
+            self._collection.add(
+                ids=[entry.id],
+                documents=[entry.answer],
+                metadatas=[
+                    {
+                        "question": entry.question,
+                        "citations": entry.citations,
+                        "key_points": entry.key_points,
+                    }
+                ],
+            )
+
+    def question_ids(self) -> Iterable[str]:
+        return self._questions.keys()
+
+    def random_question(self) -> QuestionEntry:
+        if not self._questions:
+            raise RuntimeError("Question bank is empty")
+        return random.choice(list(self._questions.values()))
+
+    def get_question(self, question_id: str) -> QuestionEntry:
+        return self._questions[question_id]
+
+    def retrieve_context(self, query: str, top_k: int = 3) -> List[dict]:
+        """Retrieve the most relevant knowledge snippets for a given query."""
+
+        results = self._collection.query(
+            query_texts=[query], n_results=top_k, include=["documents", "metadatas", "distances"]
+        )
+        contexts: List[dict] = []
+        for idx, doc_id in enumerate(results.get("ids", [[]])[0]):
+            metadata = results.get("metadatas", [[]])[0][idx]
+            document = results.get("documents", [[]])[0][idx]
+            distance = results.get("distances", [[]])[0][idx]
+            contexts.append(
+                {
+                    "id": doc_id,
+                    "context": document,
+                    "metadata": metadata,
+                    "distance": distance,
+                }
+            )
+        return contexts

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from fastapi import Depends
+
+from app.config import Settings, get_settings
+from app.db.vector_store import QuestionVectorStore
+from app.services.llm import LlamaCppBackend
+from app.services.pipeline import AssessmentPipeline
+from app.services.question_service import QuestionService
+from app.services.rag import RAGEvaluator
+from app.services.report import ReportBuilder
+from app.services.session import SessionStore
+from app.services.transcription import TranscriptionService
+from app.services.visual import LlavaVisionLanguageModel, NullVisionLanguageModel, VisualAnalyzer
+
+
+@lru_cache(maxsize=1)
+def get_session_store_singleton() -> SessionStore:
+    return SessionStore()
+
+
+@lru_cache(maxsize=1)
+def get_vector_store_singleton() -> QuestionVectorStore:
+    settings = get_settings()
+    return QuestionVectorStore(
+        dataset_path=settings.dataset_path,
+        persist_directory=settings.vector_store_path,
+        collection_name=settings.collection_name,
+        embedding_model=settings.embedding_model,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_transcription_singleton() -> TranscriptionService:
+    settings = get_settings()
+    return TranscriptionService(model_name=settings.transcription_model, language=settings.transcription_language)
+
+
+@lru_cache(maxsize=1)
+def get_llm_backend_singleton() -> Optional[LlamaCppBackend]:
+    settings = get_settings()
+    if not settings.llm_model_path:
+        return None
+    try:
+        return LlamaCppBackend(
+            model_path=settings.llm_model_path,
+            temperature=settings.llm_temperature,
+            max_tokens=settings.llm_max_tokens,
+        )
+    except Exception as exc:  # pragma: no cover - optional dependency guard
+        print(f"Failed to initialise LLM backend: {exc}")
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_visual_backend_singleton():
+    settings = get_settings()
+    if not settings.enable_vlm or not settings.vlm_model_name:
+        return NullVisionLanguageModel()
+    try:
+        return LlavaVisionLanguageModel(settings.vlm_model_name, device=settings.vlm_device)
+    except Exception as exc:  # pragma: no cover - optional dependency guard
+        print(f"Failed to initialise VLM backend: {exc}")
+        return NullVisionLanguageModel()
+
+
+@lru_cache(maxsize=1)
+def get_visual_analyzer_singleton() -> VisualAnalyzer:
+    settings = get_settings()
+    return VisualAnalyzer(settings=settings, vlm=get_visual_backend_singleton())
+
+
+@lru_cache(maxsize=1)
+def get_rag_singleton() -> RAGEvaluator:
+    settings = get_settings()
+    return RAGEvaluator(
+        store=get_vector_store_singleton(),
+        settings=settings,
+        llm_backend=get_llm_backend_singleton(),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_report_builder_singleton() -> ReportBuilder:
+    settings = get_settings()
+    return ReportBuilder(settings)
+
+
+@lru_cache(maxsize=1)
+def get_pipeline_singleton() -> AssessmentPipeline:
+    return AssessmentPipeline(
+        sessions=get_session_store_singleton(),
+        transcription=get_transcription_singleton(),
+        rag=get_rag_singleton(),
+        visual=get_visual_analyzer_singleton(),
+        report_builder=get_report_builder_singleton(),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_question_service_singleton() -> QuestionService:
+    settings = get_settings()
+    return QuestionService(get_vector_store_singleton(), get_session_store_singleton(), settings)
+
+
+def get_session_store(settings: Settings = Depends(get_settings)) -> SessionStore:  # pragma: no cover - FastAPI DI hook
+    return get_session_store_singleton()
+
+
+def get_question_service(settings: Settings = Depends(get_settings)) -> QuestionService:  # pragma: no cover
+    return get_question_service_singleton()
+
+
+def get_pipeline(settings: Settings = Depends(get_settings)) -> AssessmentPipeline:  # pragma: no cover
+    return get_pipeline_singleton()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.api.routes import router
+from app.config import get_settings
+from app.dependencies import get_pipeline, get_question_service
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    app = FastAPI(title=settings.app_name)
+    app.include_router(router)
+
+    @app.on_event("startup")
+    async def _startup_event() -> None:  # pragma: no cover - simple initialisation hook
+        # Warm up key components so the first request has low latency.
+        get_question_service()
+        get_pipeline()
+
+    return app
+
+
+app = create_app()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,9 @@
+from .domain import CompositeReport, ContentEvaluation, ExamSession, QuestionEntry, VisualAnalysis
+
+__all__ = [
+    "CompositeReport",
+    "ContentEvaluation",
+    "ExamSession",
+    "QuestionEntry",
+    "VisualAnalysis",
+]

--- a/app/models/domain.py
+++ b/app/models/domain.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class QuestionEntry:
+    """Represents a single interview question and its verified answer."""
+
+    id: str
+    question: str
+    answer: str
+    citations: List[str]
+    key_points: List[str]
+
+
+@dataclass
+class ContentEvaluation:
+    """Structured scoring output from the RAG-based content evaluation."""
+
+    accuracy_score: float
+    missed_concepts: List[str]
+    errors_made: List[str]
+    correct_points: List[str]
+    confidence: float
+
+
+@dataclass
+class VisualAnalysis:
+    """Summarises the student's delivery extracted from video analysis."""
+
+    gestures_detected: List[str]
+    confidence_estimate: str
+    engagement_level: str
+    notes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CompositeReport:
+    """Final aggregated report combining content and delivery analysis."""
+
+    question_asked: str
+    student_answer_transcript: str
+    content_analysis: ContentEvaluation
+    delivery_analysis: VisualAnalysis
+    composite_score: float
+
+
+@dataclass
+class ExamSession:
+    """Stores session state for a student's interaction."""
+
+    session_id: str
+    question: QuestionEntry
+    status: str = "awaiting_response"
+    report: Optional[CompositeReport] = None
+    transcript: Optional[str] = None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class QuestionResponse(BaseModel):
+    session_id: str = Field(..., description="Identifier for the exam session")
+    question: str = Field(..., description="Question presented to the student")
+    max_response_duration: int = Field(..., description="Allowed answer duration in seconds")
+
+
+class SubmissionResponse(BaseModel):
+    session_id: str
+    status: str
+
+
+class ContentEvaluationModel(BaseModel):
+    accuracy_score: float = Field(..., ge=0, le=100)
+    missed_concepts: List[str]
+    errors_made: List[str]
+    correct_points: List[str]
+    confidence: float = Field(..., ge=0, le=100)
+
+
+class VisualAnalysisModel(BaseModel):
+    gestures_detected: List[str]
+    confidence_estimate: str
+    engagement_level: str
+    notes: List[str] = Field(default_factory=list)
+
+
+class ExamReportModel(BaseModel):
+    question_asked: str
+    student_answer_transcript: str
+    content_analysis: ContentEvaluationModel
+    delivery_analysis: VisualAnalysisModel
+    composite_score: float = Field(..., ge=0, le=100)
+
+
+class ExamStatusResponse(BaseModel):
+    session_id: str
+    status: str
+    report: Optional[ExamReportModel] = None
+
+
+class TranscriptOnlyRequest(BaseModel):
+    session_id: str
+    transcript: str

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,4 @@
+from .pipeline import AssessmentPipeline
+from .question_service import QuestionService
+
+__all__ = ["AssessmentPipeline", "QuestionService"]

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Protocol
+
+
+class LLMBackend(Protocol):
+    """Protocol describing a minimal interface for text generation."""
+
+    def run(self, prompt: str) -> str:
+        ...
+
+
+class LlamaCppBackend:
+    """LLM backend powered by llama.cpp compatible models."""
+
+    def __init__(self, model_path: str, temperature: float = 0.1, max_tokens: int = 768) -> None:
+        try:
+            from llama_cpp import Llama
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "llama-cpp-python is not installed. Install it to enable local LLM inference."
+            ) from exc
+
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"LLM model not found at {model_path}")
+
+        self._llama = Llama(
+            model_path=model_path,
+            n_ctx=4096,
+            temperature=temperature,
+        )
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+
+    def run(self, prompt: str) -> str:
+        response = self._llama.create_chat_completion(
+            messages=[
+                {"role": "system", "content": "You produce strict, JSON-formatted evaluations."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+        return response["choices"][0]["message"]["content"]
+
+
+class HeuristicBackend:
+    """Fallback backend that produces deterministic JSON responses."""
+
+    def run(self, prompt: str) -> str:  # pragma: no cover - simple deterministic behaviour
+        try:
+            payload = json.loads(prompt)
+        except json.JSONDecodeError:
+            return json.dumps(
+                {
+                    "accuracy_score": 50.0,
+                    "missed_concepts": ["Unable to parse prompt"],
+                    "errors_made": [],
+                    "correct_points": [],
+                    "confidence": 30.0,
+                }
+            )
+        return json.dumps(payload)

--- a/app/services/pipeline.py
+++ b/app/services/pipeline.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from app.models.domain import VisualAnalysis
+from app.services.rag import RAGEvaluator
+from app.services.report import ReportBuilder
+from app.services.session import SessionStore
+from app.services.transcription import TranscriptionService
+from app.services.visual import VisualAnalyzer
+
+
+class AssessmentPipeline:
+    """Coordinates audio transcription, RAG evaluation, and visual analysis."""
+
+    def __init__(
+        self,
+        sessions: SessionStore,
+        transcription: TranscriptionService,
+        rag: RAGEvaluator,
+        visual: VisualAnalyzer,
+        report_builder: ReportBuilder,
+    ) -> None:
+        self._sessions = sessions
+        self._transcription = transcription
+        self._rag = rag
+        self._visual = visual
+        self._report_builder = report_builder
+
+    def process(
+        self,
+        session_id: str,
+        audio_path: Optional[Path] = None,
+        video_path: Optional[Path] = None,
+        transcript: Optional[str] = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        self._sessions.update_status(session_id, "processing")
+
+        if transcript is None:
+            if audio_path is None:
+                raise ValueError("Either transcript or audio_path must be provided")
+            transcript = self._transcription.transcribe(audio_path)
+        self._sessions.attach_transcript(session_id, transcript)
+
+        content = self._rag.evaluate(session.question, transcript)
+        visual = self._analyze_video(video_path)
+        report = self._report_builder.build(
+            question_text=session.question.question,
+            transcript=transcript,
+            content=content,
+            visual=visual,
+        )
+        self._sessions.attach_report(session_id, report)
+        self._cleanup_file(audio_path)
+        self._cleanup_file(video_path)
+
+    def _analyze_video(self, video_path: Optional[Path]) -> VisualAnalysis:
+        if video_path is None:
+            return VisualAnalysis(
+                gestures_detected=["analysis_unavailable"],
+                confidence_estimate="low",
+                engagement_level="low",
+                notes=["No video provided"],
+            )
+        return self._visual.analyze(video_path)
+
+    def _cleanup_file(self, file_path: Optional[Path]) -> None:
+        if file_path is None:
+            return
+        try:
+            file_path.unlink(missing_ok=True)
+        except Exception:
+            pass

--- a/app/services/question_service.py
+++ b/app/services/question_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.config import Settings
+from app.db.vector_store import QuestionVectorStore
+from app.models.domain import ExamSession
+from app.services.session import SessionStore
+
+
+class QuestionService:
+    """Handles retrieval of questions and creation of interview sessions."""
+
+    def __init__(
+        self,
+        store: QuestionVectorStore,
+        session_store: SessionStore,
+        settings: Settings,
+    ) -> None:
+        self._store = store
+        self._sessions = session_store
+        self._settings = settings
+
+    def start_new_session(self) -> ExamSession:
+        question = self._store.random_question()
+        session = ExamSession(session_id=uuid4().hex, question=question)
+        self._sessions.add(session)
+        return session
+
+    def get_session(self, session_id: str) -> ExamSession:
+        return self._sessions.get(session_id)
+
+    @property
+    def answer_duration_seconds(self) -> int:
+        return self._settings.question_duration_seconds

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import Dict, List, Optional
+
+from app.config import Settings
+from app.db.vector_store import QuestionVectorStore
+from app.models.domain import ContentEvaluation, QuestionEntry
+from app.services.llm import HeuristicBackend, LLMBackend
+
+
+class RAGEvaluator:
+    """Combines retrieval and generation to grade a spoken answer."""
+
+    def __init__(
+        self,
+        store: QuestionVectorStore,
+        settings: Settings,
+        llm_backend: Optional[LLMBackend] = None,
+    ) -> None:
+        self._store = store
+        self._settings = settings
+        self._llm = llm_backend or HeuristicBackend()
+
+    def evaluate(self, question: QuestionEntry, transcript: str) -> ContentEvaluation:
+        contexts = self._store.retrieve_context(transcript or question.answer, top_k=3)
+        prompt = self._build_prompt(question, transcript, contexts)
+        raw_response = self._llm.run(prompt)
+        parsed = self._parse_response(raw_response)
+        if not parsed:
+            parsed = self._heuristic_evaluation(question, transcript, contexts)
+        return ContentEvaluation(**parsed)
+
+    def _build_prompt(self, question: QuestionEntry, transcript: str, contexts: List[dict]) -> str:
+        payload = {
+            "question": question.question,
+            "transcript": transcript,
+            "context": contexts,
+            "instructions": self._settings.evaluation_prompt_template,
+        }
+        return json.dumps(payload)
+
+    def _parse_response(self, response: str) -> Optional[Dict[str, object]]:
+        json_blob = self._extract_json(response)
+        if not json_blob:
+            return None
+        try:
+            parsed = json.loads(json_blob)
+        except json.JSONDecodeError:
+            return None
+
+        expected_keys = {"accuracy_score", "missed_concepts", "errors_made", "correct_points", "confidence"}
+        if not expected_keys.issubset(parsed):
+            return None
+        return parsed
+
+    def _extract_json(self, text: str) -> Optional[str]:
+        match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+        return match.group(0) if match else None
+
+    def _heuristic_evaluation(
+        self, question: QuestionEntry, transcript: str, contexts: List[dict]
+    ) -> Dict[str, object]:  # pragma: no cover - deterministic simple heuristic
+        transcript_lower = transcript.lower()
+        key_points = self._aggregate_key_points(question, contexts)
+        covered = []
+        missed = []
+        for point in key_points:
+            similarity = self._phrase_similarity(point.lower(), transcript_lower)
+            if similarity >= 0.55:
+                covered.append(point)
+            else:
+                missed.append(point)
+
+        accuracy = 100 * len(covered) / len(key_points) if key_points else 30.0
+        confidence = max(40.0, min(95.0, accuracy - 5.0))
+
+        return {
+            "accuracy_score": round(accuracy, 2),
+            "missed_concepts": missed,
+            "errors_made": [],
+            "correct_points": covered,
+            "confidence": round(confidence, 2),
+        }
+
+    def _aggregate_key_points(self, question: QuestionEntry, contexts: List[dict]) -> List[str]:
+        unique = set(question.key_points)
+        for ctx in contexts:
+            metadata = ctx.get("metadata") or {}
+            for point in metadata.get("key_points", []):
+                unique.add(point)
+        return list(unique)
+
+    def _phrase_similarity(self, phrase: str, transcript: str) -> float:
+        if not phrase:
+            return 0.0
+        overlap = sum(1 for token in phrase.split() if token in transcript)
+        return overlap / math.sqrt(len(phrase.split()) or 1)

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from app.config import Settings
+from app.models.domain import CompositeReport, ContentEvaluation, VisualAnalysis
+
+
+class ReportBuilder:
+    """Combines content and delivery analysis into a single JSON-friendly report."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+
+    def build(
+        self,
+        question_text: str,
+        transcript: str,
+        content: ContentEvaluation,
+        visual: VisualAnalysis,
+    ) -> CompositeReport:
+        delivery_score = self._delivery_score(visual)
+        composite = (
+            content.accuracy_score * self._settings.composite_score_content_weight
+            + delivery_score * self._settings.composite_score_delivery_weight
+        )
+        composite = max(0.0, min(100.0, composite))
+        return CompositeReport(
+            question_asked=question_text,
+            student_answer_transcript=transcript,
+            content_analysis=content,
+            delivery_analysis=visual,
+            composite_score=round(composite, 2),
+        )
+
+    def _delivery_score(self, visual: VisualAnalysis) -> float:
+        base = {"low": 40.0, "medium": 70.0, "high": 90.0}.get(visual.engagement_level, 50.0)
+        bonus = min(10.0, 2.5 * len(visual.gestures_detected))
+        if visual.confidence_estimate == "high":
+            bonus += 5.0
+        if "analysis_unavailable" in visual.gestures_detected:
+            return 50.0
+        return max(30.0, min(95.0, base + bonus))

--- a/app/services/session.py
+++ b/app/services/session.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from threading import Lock
+from typing import Dict, Optional
+
+from app.models.domain import CompositeReport, ExamSession
+
+
+class SessionStore:
+    """Thread-safe in-memory session store suitable for prototyping."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, ExamSession] = {}
+        self._lock = Lock()
+
+    def add(self, session: ExamSession) -> None:
+        with self._lock:
+            self._sessions[session.session_id] = session
+
+    def get(self, session_id: str) -> ExamSession:
+        with self._lock:
+            if session_id not in self._sessions:
+                raise KeyError(f"Unknown session_id {session_id}")
+            return self._sessions[session_id]
+
+    def update_status(self, session_id: str, status: str) -> None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise KeyError(f"Unknown session_id {session_id}")
+            session.status = status
+
+    def attach_transcript(self, session_id: str, transcript: str) -> None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise KeyError(f"Unknown session_id {session_id}")
+            session.transcript = transcript
+
+    def attach_report(self, session_id: str, report: CompositeReport) -> None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise KeyError(f"Unknown session_id {session_id}")
+            session.report = report
+            session.status = "completed"
+
+    def maybe_get(self, session_id: str) -> Optional[ExamSession]:
+        with self._lock:
+            return self._sessions.get(session_id)

--- a/app/services/transcription.py
+++ b/app/services/transcription.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+class TranscriptionService:
+    """Wrapper around Whisper speech-to-text transcription."""
+
+    def __init__(self, model_name: str = "base", language: Optional[str] = "en") -> None:
+        self._model_name = model_name
+        self._language = language
+        self._model = None
+
+    def _load_model(self):
+        if self._model is not None:
+            return self._model
+        try:
+            import whisper
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "openai-whisper is not installed. Install it or provide a custom transcription backend."
+            ) from exc
+        self._model = whisper.load_model(self._model_name)
+        return self._model
+
+    def transcribe(self, audio_path: Path) -> str:
+        model = self._load_model()
+        result = model.transcribe(str(audio_path), language=self._language)
+        return str(result.get("text", "")).strip()

--- a/app/services/visual.py
+++ b/app/services/visual.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import List, Optional, Set
+
+import numpy as np
+
+from app.config import Settings
+from app.models.domain import VisualAnalysis
+
+try:  # pragma: no cover - heavy optional dependency
+    import cv2
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise RuntimeError("opencv-python is required for video analysis") from exc
+
+
+class BaseVisionLanguageModel:
+    """Base interface for vision-language reasoning."""
+
+    def describe(self, image: np.ndarray, prompt: str) -> str:
+        raise NotImplementedError
+
+
+class NullVisionLanguageModel(BaseVisionLanguageModel):
+    def describe(self, image: np.ndarray, prompt: str) -> str:  # pragma: no cover - simple passthrough
+        return ""
+
+
+class LlavaVisionLanguageModel(BaseVisionLanguageModel):
+    """Wrapper around an open VLM such as LLaVA."""
+
+    def __init__(self, model_name: str, device: str = "cpu") -> None:
+        try:
+            import torch
+            from PIL import Image
+            from transformers import AutoProcessor, LlavaForConditionalGeneration
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("Install transformers[torch] and pillow to use a VLM backend") from exc
+
+        self._processor = AutoProcessor.from_pretrained(model_name)
+        torch_dtype = torch.float16 if device != "cpu" else torch.float32
+        self._model = LlavaForConditionalGeneration.from_pretrained(
+            model_name,
+            torch_dtype=torch_dtype,
+            device_map=device,
+        )
+        self._device = self._model.device
+        self._Image = Image
+
+    def describe(self, image: np.ndarray, prompt: str) -> str:
+        pil_image = self._Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+        inputs = self._processor(images=pil_image, text=prompt, return_tensors="pt").to(self._device)
+        output = self._model.generate(**inputs, max_new_tokens=128)
+        text = self._processor.batch_decode(output, skip_special_tokens=True)[0]
+        return text.strip()
+
+
+class VisualAnalyzer:
+    """Extracts gestures and higher-level descriptors from a video segment."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        vlm: Optional[BaseVisionLanguageModel] = None,
+    ) -> None:
+        self._settings = settings
+        self._vlm = vlm or NullVisionLanguageModel()
+        self._holistic = self._create_holistic()
+
+    def _create_holistic(self):  # pragma: no cover - optional dependency initialisation
+        try:
+            import mediapipe as mp
+        except ImportError:
+            return None
+        return mp.solutions.holistic.Holistic(static_image_mode=True, model_complexity=1)
+
+    def analyze(self, video_path: Path) -> VisualAnalysis:
+        frames = self._extract_key_frames(video_path)
+        if not frames:
+            return VisualAnalysis(
+                gestures_detected=["analysis_unavailable"],
+                confidence_estimate="low",
+                engagement_level="low",
+                notes=["Video contained no readable frames"],
+            )
+        gestures: Set[str] = set()
+        notes: List[str] = []
+        for frame in frames:
+            gestures.update(self._detect_gestures(frame))
+            description = self._vlm.describe(frame, self._vlm_prompt())
+            if description:
+                notes.append(description)
+
+        engagement = self._derive_engagement(len(frames), len(gestures))
+        confidence = self._derive_confidence(len(gestures), notes)
+
+        return VisualAnalysis(
+            gestures_detected=sorted(gestures),
+            confidence_estimate=confidence,
+            engagement_level=engagement,
+            notes=notes,
+        )
+
+    def _extract_key_frames(self, video_path: Path) -> List[np.ndarray]:
+        cap = cv2.VideoCapture(str(video_path))
+        if not cap.isOpened():  # pragma: no cover - runtime guard
+            raise RuntimeError(f"Unable to open video file: {video_path}")
+
+        fps = cap.get(cv2.CAP_PROP_FPS) or 25.0
+        frame_interval = max(int(fps * self._settings.keyframe_window_seconds), 1)
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        frames: List[np.ndarray] = []
+
+        for frame_idx in range(0, total_frames, frame_interval):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+            success, frame = cap.read()
+            if not success:
+                continue
+            frames.append(frame)
+            if len(frames) >= self._settings.max_keyframes:
+                break
+
+        cap.release()
+        return frames
+
+    def _detect_gestures(self, frame: np.ndarray) -> Set[str]:
+        results = self._run_holistic(frame)
+        if results is None:
+            return {"analysis_unavailable"}
+
+        gestures: Set[str] = set()
+        mp = self._mediapipe_module()
+        if results.left_hand_landmarks:
+            gestures.update(self._classify_hand(results.left_hand_landmarks, results.pose_landmarks, mp))
+        if results.right_hand_landmarks:
+            gestures.update(self._classify_hand(results.right_hand_landmarks, results.pose_landmarks, mp))
+        if not gestures:
+            gestures.add("low_gesture_activity")
+        return gestures
+
+    def _run_holistic(self, frame: np.ndarray):
+        if self._holistic is None:
+            return None
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return self._holistic.process(rgb)
+
+    def _mediapipe_module(self):  # pragma: no cover - helper for optional dependency
+        import mediapipe as mp
+
+        return mp
+
+    def _classify_hand(self, hand_landmarks, pose_landmarks, mp) -> Set[str]:  # pragma: no cover - heavy
+        gestures: Set[str] = set()
+        index_tip = hand_landmarks.landmark[mp.solutions.hands.HandLandmark.INDEX_FINGER_TIP]
+        index_mcp = hand_landmarks.landmark[mp.solutions.hands.HandLandmark.INDEX_FINGER_MCP]
+        middle_tip = hand_landmarks.landmark[mp.solutions.hands.HandLandmark.MIDDLE_FINGER_TIP]
+        ring_tip = hand_landmarks.landmark[mp.solutions.hands.HandLandmark.RING_FINGER_TIP]
+        pinky_tip = hand_landmarks.landmark[mp.solutions.hands.HandLandmark.PINKY_TIP]
+
+        extended_fingers = sum(
+            tip.y < index_mcp.y for tip in (index_tip, middle_tip, ring_tip, pinky_tip)
+        )
+        if index_tip.y < index_mcp.y and middle_tip.y > index_mcp.y:
+            gestures.add("pointing")
+        if extended_fingers >= 3:
+            gestures.add("counting")
+
+        if pose_landmarks:
+            nose = pose_landmarks.landmark[mp.solutions.pose.PoseLandmark.NOSE]
+            distance = math.sqrt(
+                (index_tip.x - nose.x) ** 2 + (index_tip.y - nose.y) ** 2 + (index_tip.z - nose.z) ** 2
+            )
+            if distance < 0.1:
+                gestures.add("thinking")
+
+        if not gestures:
+            gestures.add("expressive_hand_gesture")
+        return gestures
+
+    def _derive_engagement(self, frame_count: int, gesture_count: int) -> str:
+        if gesture_count == 0 or frame_count == 0:
+            return "low"
+        ratio = gesture_count / max(frame_count, 1)
+        if ratio > 0.15:
+            return "high"
+        if ratio > 0.05:
+            return "medium"
+        return "low"
+
+    def _derive_confidence(self, gesture_count: int, notes: List[str]) -> str:
+        if gesture_count >= 3 or any("confident" in note.lower() for note in notes):
+            return "high"
+        if gesture_count == 0:
+            return "low"
+        return "medium"
+
+    def _vlm_prompt(self) -> str:
+        return (
+            "Analyze this video frame of a student. Describe their non-verbal communication. "
+            "Do they appear confident, hesitant, or thoughtful? Are they using descriptive hand gestures "
+            "relevant to explaining a technical concept? Note any significant facial expressions or posture."
+        )

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from celery import Celery
+
+from app.config import get_settings
+from app.dependencies import get_pipeline
+
+settings = get_settings()
+
+celery_app = Celery(
+    "assessment",
+    broker=settings.celery_broker_url,
+    backend=settings.celery_result_backend,
+)
+
+
+@celery_app.task(name="assessment.process_submission")
+def process_submission_task(
+    session_id: str,
+    audio_path: Optional[str] = None,
+    video_path: Optional[str] = None,
+    transcript: Optional[str] = None,
+) -> bool:
+    pipeline = get_pipeline()
+    pipeline.process(
+        session_id=session_id,
+        audio_path=Path(audio_path) if audio_path else None,
+        video_path=Path(video_path) if video_path else None,
+        transcript=transcript,
+    )
+    return True

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "q1",
+    "question": "Explain the concept of least squares estimation in linear regression.",
+    "answer": "Least squares estimation finds coefficients by minimizing the sum of squared residuals between observed responses and the model's fitted values. It leads to closed-form normal equations and an optimal unbiased estimator under the Gauss-Markov assumptions.",
+    "citations": [
+      "Montgomery, D. C., Peck, E. A., & Vining, G. G. (2012). Introduction to Linear Regression Analysis.",
+      "Seber, G. A., & Lee, A. J. (2012). Linear Regression Analysis."
+    ],
+    "key_points": [
+      "Minimize sum of squared residuals",
+      "Derive normal equations",
+      "Gauss-Markov optimality"
+    ]
+  },
+  {
+    "id": "q2",
+    "question": "What does the coefficient in a linear regression model represent?",
+    "answer": "In a linear regression model, a coefficient quantifies the expected change in the response variable for a one-unit increase in the associated predictor while holding other predictors constant. It reflects partial effect and directionality.",
+    "citations": [
+      "Wooldridge, J. M. (2013). Introductory Econometrics: A Modern Approach.",
+      "Kutner, M. H., Nachtsheim, C. J., & Neter, J. (2004). Applied Linear Regression Models."
+    ],
+    "key_points": [
+      "Marginal effect",
+      "Holds other predictors fixed",
+      "Direction and magnitude"
+    ]
+  },
+  {
+    "id": "q3",
+    "question": "Define the Gauss-Markov assumptions necessary for the ordinary least squares estimator to be BLUE.",
+    "answer": "The Gauss-Markov assumptions include linearity in parameters, random sampling, full column rank (no perfect multicollinearity), zero conditional mean of errors, and homoscedasticity. Under these assumptions the OLS estimator is the Best Linear Unbiased Estimator (BLUE).",
+    "citations": [
+      "Hayashi, F. (2000). Econometrics.",
+      "Greene, W. H. (2018). Econometric Analysis."
+    ],
+    "key_points": [
+      "Linearity",
+      "Random sampling",
+      "No perfect multicollinearity",
+      "Zero conditional mean",
+      "Homoscedasticity"
+    ]
+  },
+  {
+    "id": "q4",
+    "question": "How do you interpret the R-squared metric in linear regression?",
+    "answer": "R-squared measures the proportion of variance in the dependent variable explained by the regressors. It is calculated as one minus the ratio of the residual sum of squares to the total sum of squares. Higher values indicate better fit but do not imply causality or guarantee predictive performance.",
+    "citations": [
+      "James, G., Witten, D., Hastie, T., & Tibshirani, R. (2013). An Introduction to Statistical Learning.",
+      "Kutner, M. H., Nachtsheim, C. J., & Neter, J. (2004). Applied Linear Regression Models."
+    ],
+    "key_points": [
+      "Variance explained",
+      "1 - RSS/TSS",
+      "Does not imply causality"
+    ]
+  },
+  {
+    "id": "q5",
+    "question": "What is multicollinearity and how can it affect a linear regression model?",
+    "answer": "Multicollinearity occurs when predictors are highly linearly correlated, leading to unstable coefficient estimates, inflated standard errors, and difficulty interpreting individual effects. Diagnostics include variance inflation factors and condition indices. Mitigation strategies involve removing variables, combining them, or using regularization.",
+    "citations": [
+      "Belsley, D. A., Kuh, E., & Welsch, R. E. (2005). Regression Diagnostics.",
+      "Montgomery, D. C., Peck, E. A., & Vining, G. G. (2012). Introduction to Linear Regression Analysis."
+    ],
+    "key_points": [
+      "High predictor correlation",
+      "Inflated standard errors",
+      "Diagnostics and remedies"
+    ]
+  },
+  {
+    "id": "q6",
+    "question": "Describe how to perform residual analysis to validate a linear regression model.",
+    "answer": "Residual analysis involves examining plots of residuals versus fitted values for patterns, assessing normality with Q-Q plots, checking for heteroscedasticity, and identifying influential points using leverage and Cook's distance. The goal is to confirm model assumptions and highlight needed adjustments.",
+    "citations": [
+      "Montgomery, D. C., Peck, E. A., & Vining, G. G. (2012). Introduction to Linear Regression Analysis.",
+      "Fox, J. (2016). Applied Regression Analysis and Generalized Linear Models."
+    ],
+    "key_points": [
+      "Residual vs fitted plots",
+      "Normality diagnostics",
+      "Influence measures"
+    ]
+  },
+  {
+    "id": "q7",
+    "question": "Explain the difference between bias and variance in the context of linear regression.",
+    "answer": "Bias measures the error introduced by approximating a complex relationship with a simpler model, whereas variance reflects how much the estimator would change with different samples. A good model balances bias and variance to minimize expected prediction error.",
+    "citations": [
+      "Hastie, T., Tibshirani, R., & Friedman, J. (2009). The Elements of Statistical Learning.",
+      "James, G., Witten, D., Hastie, T., & Tibshirani, R. (2013). An Introduction to Statistical Learning."
+    ],
+    "key_points": [
+      "Bias definition",
+      "Variance definition",
+      "Trade-off"
+    ]
+  },
+  {
+    "id": "q8",
+    "question": "How does regularization (Ridge or Lasso) modify the linear regression objective?",
+    "answer": "Regularization adds a penalty to the least squares objective: Ridge includes an L2 penalty on coefficients, while Lasso uses an L1 penalty that can drive coefficients to zero. These penalties reduce overfitting and handle multicollinearity by shrinking coefficient magnitudes.",
+    "citations": [
+      "Hastie, T., Tibshirani, R., & Friedman, J. (2009). The Elements of Statistical Learning.",
+      "James, G., Witten, D., Hastie, T., & Tibshirani, R. (2013). An Introduction to Statistical Learning."
+    ],
+    "key_points": [
+      "Add penalty to loss",
+      "Ridge L2 shrinkage",
+      "Lasso L1 sparsity"
+    ]
+  },
+  {
+    "id": "q9",
+    "question": "What assumptions must hold for hypothesis tests on regression coefficients to be valid?",
+    "answer": "Hypothesis tests on coefficients require that errors are normally distributed with constant variance and zero mean, observations are independent, and the model is correctly specified. These ensure the t-statistics follow their reference distribution for inference.",
+    "citations": [
+      "Wooldridge, J. M. (2013). Introductory Econometrics: A Modern Approach.",
+      "Greene, W. H. (2018). Econometric Analysis."
+    ],
+    "key_points": [
+      "Normality",
+      "Independence",
+      "Homoscedasticity",
+      "Correct specification"
+    ]
+  },
+  {
+    "id": "q10",
+    "question": "Describe how cross-validation can be used to assess a linear regression model.",
+    "answer": "Cross-validation partitions the data into folds, fits the model on training folds, and evaluates predictive performance on held-out folds. Averaging the error across folds estimates generalization error and aids model selection, such as choosing regularization strength.",
+    "citations": [
+      "James, G., Witten, D., Hastie, T., & Tibshirani, R. (2013). An Introduction to Statistical Learning.",
+      "Hastie, T., Tibshirani, R., & Friedman, J. (2009). The Elements of Statistical Learning."
+    ],
+    "key_points": [
+      "Partition data into folds",
+      "Train/validate cycle",
+      "Estimate generalization error"
+    ]
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+pydantic-settings>=2.2.1
+chromadb>=0.5.0
+sentence-transformers>=2.5.1
+numpy>=1.24
+python-multipart>=0.0.9
+openai-whisper>=20231117
+opencv-python>=4.9.0
+mediapipe>=0.10.0
+pillow>=10.0.0
+transformers>=4.39.0
+celery>=5.3.0
+redis>=5.0.0
+llama-cpp-python>=0.2.60


### PR DESCRIPTION
## Summary
- stand up a FastAPI service that manages exam sessions, transcription, retrieval-augmented grading, and visual analysis
- provision a Chroma-backed question bank, reusable services, and Celery worker hooks for asynchronous processing
- document environment setup, configuration, and API workflows for the oral assessment pipeline

## Testing
- python -m compileall app
- python -m compileall celery_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6b58254083318883cadce7f1d917