### PR TITLE
Add Redis-backed session storage for Celery workers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     celery_broker_url: str = "redis://localhost:6379/0"
     celery_result_backend: str = "redis://localhost:6379/1"
     use_celery: bool = False
+    session_store_url: Optional[str] = None
 
     model_config = SettingsConfigDict(env_prefix="INTERVIEW_", env_file=".env", env_file_encoding="utf-8")
 

--- a/app/services/session.py
+++ b/app/services/session.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+import json
+from dataclasses import asdict
 from threading import Lock
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 
-from app.models.domain import CompositeReport, ExamSession
+from app.models.domain import (
+    CompositeReport,
+    ContentEvaluation,
+    ExamSession,
+    QuestionEntry,
+    VisualAnalysis,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from redis.client import Redis
 
 
 class SessionStore:
@@ -48,3 +59,82 @@ class SessionStore:
     def maybe_get(self, session_id: str) -> Optional[ExamSession]:
         with self._lock:
             return self._sessions.get(session_id)
+
+
+class RedisSessionStore(SessionStore):
+    """Redis-backed session store that persists state across processes."""
+
+    def __init__(self, redis_client: "Redis", key_prefix: str = "session:") -> None:
+        # Intentionally skip super().__init__ to avoid the in-memory structures.
+        self._redis = redis_client
+        self._key_prefix = key_prefix
+
+    def add(self, session: ExamSession) -> None:
+        mapping = {
+            "question": json.dumps(asdict(session.question)),
+            "status": session.status,
+            "transcript": session.transcript or "",
+            "report": json.dumps(asdict(session.report)) if session.report else "",
+        }
+        self._redis.hset(self._key(session.session_id), mapping=mapping)
+
+    def get(self, session_id: str) -> ExamSession:
+        data = self._redis.hgetall(self._key(session_id))
+        if not data:
+            raise KeyError(f"Unknown session_id {session_id}")
+        return self._deserialize_session(session_id, data)
+
+    def update_status(self, session_id: str, status: str) -> None:
+        key = self._ensure_exists(session_id)
+        self._redis.hset(key, mapping={"status": status})
+
+    def attach_transcript(self, session_id: str, transcript: str) -> None:
+        key = self._ensure_exists(session_id)
+        self._redis.hset(key, mapping={"transcript": transcript})
+
+    def attach_report(self, session_id: str, report: CompositeReport) -> None:
+        key = self._ensure_exists(session_id)
+        payload = json.dumps(asdict(report))
+        self._redis.hset(key, mapping={"report": payload, "status": "completed"})
+
+    def maybe_get(self, session_id: str) -> Optional[ExamSession]:
+        data = self._redis.hgetall(self._key(session_id))
+        if not data:
+            return None
+        return self._deserialize_session(session_id, data)
+
+    def _key(self, session_id: str) -> str:
+        return f"{self._key_prefix}{session_id}"
+
+    def _ensure_exists(self, session_id: str) -> str:
+        key = self._key(session_id)
+        if not self._redis.exists(key):
+            raise KeyError(f"Unknown session_id {session_id}")
+        return key
+
+    def _deserialize_session(self, session_id: str, data: Dict[str, str]) -> ExamSession:
+        question = QuestionEntry(**json.loads(data["question"]))
+        report = self._deserialize_report(data.get("report"))
+        transcript = data.get("transcript") or None
+        status = data.get("status", "awaiting_response")
+        return ExamSession(
+            session_id=session_id,
+            question=question,
+            status=status,
+            report=report,
+            transcript=transcript,
+        )
+
+    def _deserialize_report(self, payload: Optional[str]) -> Optional[CompositeReport]:
+        if not payload:
+            return None
+        data = json.loads(payload)
+        content = ContentEvaluation(**data["content_analysis"])
+        delivery = VisualAnalysis(**data["delivery_analysis"])
+        return CompositeReport(
+            question_asked=data["question_asked"],
+            student_answer_transcript=data["student_answer_transcript"],
+            content_analysis=content,
+            delivery_analysis=delivery,
+            composite_score=data["composite_score"],
+        )

--- a/celery_app.py
+++ b/celery_app.py
@@ -6,7 +6,7 @@ from typing import Optional
 from celery import Celery
 
 from app.config import get_settings
-from app.dependencies import get_pipeline
+from app.dependencies import get_pipeline, get_session_store_singleton
 
 settings = get_settings()
 
@@ -24,6 +24,8 @@ def process_submission_task(
     video_path: Optional[str] = None,
     transcript: Optional[str] = None,
 ) -> bool:
+    # Ensure the worker initialises the same session backend as the API process.
+    get_session_store_singleton()
     pipeline = get_pipeline()
     pipeline.process(
         session_id=session_id,


### PR DESCRIPTION
## Summary
- implement a Redis-backed session store that serialises sessions into Redis hashes so Celery workers and the API share state
- extend configuration with an optional INTERVIEW_SESSION_STORE_URL and wire dependencies to prefer Redis when Celery is enabled
- document a Celery regression checklist covering API/worker startup and completed submission verification

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d7f156fa008331896232349158e5a2